### PR TITLE
Select device ID when using rtaudio

### DIFF
--- a/src/AudioInterface.h
+++ b/src/AudioInterface.h
@@ -151,6 +151,8 @@ public:
   { mNumOutChans = nchannels; }
   virtual void setSampleRate(uint32_t sample_rate)
   { mSampleRate = sample_rate; }
+  virtual void setDeviceID(uint32_t device_id)
+  { mDeviceID = device_id; }
   virtual void setBufferSizeInSamples(uint32_t buf_size)
   { mBufferSizeInSamples = buf_size; }
   /// \brief Set Client Name to something different that the default (JackTrip)
@@ -164,6 +166,8 @@ public:
   virtual int getNumOutputChannels() const  { return mNumOutChans; }
   virtual uint32_t getBufferSizeInSamples() const
   { return mBufferSizeInSamples; }
+  virtual uint32_t getDeviceID() const
+  { return mDeviceID; }
   virtual size_t getSizeInBytesPerChannel() const;
   /// \brief Get the Jack Server Sampling Rate, in samples/second
   virtual uint32_t getSampleRate() const
@@ -200,6 +204,7 @@ private:
   int mAudioBitResolution; ///< Bit resolution in audio samples
   AudioInterface::audioBitResolutionT mBitResolutionMode; ///< Bit resolution (audioBitResolutionT) mode
   uint32_t mSampleRate; ///< Sampling Rate
+  uint32_t mDeviceID; ///< RTAudio DeviceID
   uint32_t mBufferSizeInSamples; ///< Buffer size in samples
   size_t mSizeInBytesPerChannel; ///< Size in bytes per audio channel
   QVector<ProcessPlugin*> mProcessPlugins; ///< Vector of ProcesPlugin<EM>s</EM>

--- a/src/JackTrip.cpp
+++ b/src/JackTrip.cpp
@@ -82,6 +82,7 @@ JackTrip::JackTrip(jacktripModeT JacktripMode,
   mNumChans(NumChans),
   mBufferQueueLength(BufferQueueLength),
   mSampleRate(gDefaultSampleRate),
+  mDeviceID(gDefaultDeviceID),
   mAudioBufferSize(gDefaultBufferSizeInSamples),
   mAudioBitResolution(AudioBitResolution),
   mDataProtocolSender(NULL),
@@ -139,6 +140,7 @@ void JackTrip::setupAudio()
     mAudioInterface->setClientName(mJackClientName);
     mAudioInterface->setup();
     mSampleRate = mAudioInterface->getSampleRate();
+    mDeviceID = mAudioInterface->getDeviceID();
     mAudioBufferSize = mAudioInterface->getBufferSizeInSamples();
 #endif //__NON_JACK__
 #ifdef __NO_JACK__ /// \todo FIX THIS REPETITION OF CODE
@@ -146,6 +148,7 @@ void JackTrip::setupAudio()
     cout << "Warning: using non jack version, RtAudio will be used instead" << endl;
     mAudioInterface = new RtAudioInterface(this, mNumChans, mNumChans, mAudioBitResolution);
     mAudioInterface->setSampleRate(mSampleRate);
+    mAudioInterface->setDeviceID(mDeviceID);
     mAudioInterface->setBufferSizeInSamples(mAudioBufferSize);
     mAudioInterface->setup();
 #endif
@@ -155,6 +158,7 @@ void JackTrip::setupAudio()
 #ifdef __RT_AUDIO__
     mAudioInterface = new RtAudioInterface(this, mNumChans, mNumChans, mAudioBitResolution);
     mAudioInterface->setSampleRate(mSampleRate);
+    mAudioInterface->setDeviceID(mDeviceID);
     mAudioInterface->setBufferSizeInSamples(mAudioBufferSize);
     mAudioInterface->setup();
 #endif
@@ -168,6 +172,8 @@ void JackTrip::setupAudio()
       << " bytes" << std::endl;
   std::cout << gPrintSeparator << std::endl;
   cout << "The Number of Channels is: " << mAudioInterface->getNumInputChannels() << endl;
+  std::cout << gPrintSeparator << std::endl;
+  cout << "The RTAudio device ID is: " << mAudioInterface->getDeviceID() << endl;
   std::cout << gPrintSeparator << std::endl;
   QThread::usleep(100);
 }

--- a/src/JackTrip.h
+++ b/src/JackTrip.h
@@ -259,8 +259,11 @@ public:
 
   void setSampleRate(uint32_t sample_rate)
   { mSampleRate = sample_rate; }
+  void setDeviceID(uint32_t device_id)
+  { mDeviceID = device_id; }
   void setAudioBufferSizeInSamples(uint32_t buf_size)
   { mAudioBufferSize = buf_size; }
+  
 
   JackTrip::connectionModeT getConnectionMode() const
   { return mConnectionMode; }
@@ -300,6 +303,8 @@ public:
   { mReceiveRingBuffer->insertSlotNonBlocking(ptrToSlot); }
   uint32_t getBufferSizeInSamples() const
   { return mAudioBufferSize; /*return mAudioInterface->getBufferSizeInSamples();*/ }
+  uint32_t getDeviceID() const
+  { return mDeviceID; /*return mAudioInterface->mDeviceID();*/ }
 
   AudioInterface::samplingRateT getSampleRateType() const
   { return mAudioInterface->getSampleRateType(); }
@@ -431,6 +436,7 @@ private:
   int mNumChans; ///< Number of Channels (inputs = outputs)
   int mBufferQueueLength; ///< Audio Buffer from network queue length
   uint32_t mSampleRate; ///< Sample Rate
+  uint32_t mDeviceID; ///< RTAudio DeviceID
   uint32_t mAudioBufferSize; ///< Audio buffer size to process on each callback
   AudioInterface::audioBitResolutionT mAudioBitResolution; ///< Audio Bit Resolutions
   QString mPeerAddress; ///< Peer Address to use in jacktripModeT::CLIENT Mode

--- a/src/RtAudioInterface.cpp
+++ b/src/RtAudioInterface.cpp
@@ -85,10 +85,10 @@ void RtAudioInterface::setup()
   RtAudio::DeviceInfo info_input;
   RtAudio::DeviceInfo info_output;
 
-  int deviceId_input; int deviceId_output;
+  uint32_t deviceId_input; uint32_t deviceId_output;
   // use default devices
-  deviceId_input = mRtAudio->getDefaultInputDevice();
-  deviceId_output = mRtAudio->getDefaultOutputDevice();
+  deviceId_input = mJackTrip->getDeviceID();
+  deviceId_output = mJackTrip->getDeviceID();
 
   cout << "DEFAULT INPUT DEVICE  : " << endl;
   printDeviceInfo(deviceId_input);
@@ -98,8 +98,8 @@ void RtAudioInterface::setup()
   cout << gPrintSeparator << endl;
 
   RtAudio::StreamParameters in_params, out_params;
-  in_params.deviceId = mRtAudio->getDefaultInputDevice();
-  out_params.deviceId = mRtAudio->getDefaultOutputDevice();
+  in_params.deviceId = deviceId_input;
+  out_params.deviceId = deviceId_output;
   in_params.nChannels = getNumInputChannels();
   out_params.nChannels = getNumOutputChannels();
 

--- a/src/RtAudioInterface.h
+++ b/src/RtAudioInterface.h
@@ -38,7 +38,7 @@
 #ifndef __RTAUDIOINTERFACE_H__
 #define __RTAUDIOINTERFACE_H__
 
-#include "RtAudio.h"
+#include "rtaudio/RtAudio.h"
 
 #include "AudioInterface.h"
 #include "jacktrip_globals.h"

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -72,6 +72,7 @@ Settings::Settings() :
     mRedundancy(1),
     mUseJack(true),
     mChanfeDefaultSR(false),
+    mChanfeDefaultID(0),
     mChanfeDefaultBS(false),
     mConnectDefaultAudioPorts(true)
 {}
@@ -119,6 +120,7 @@ void Settings::parseInput(int argc, char** argv)
         { "clientname", required_argument, NULL, 'J' }, // Run in JamLink mode
         { "rtaudio", no_argument, NULL, 'R' }, // Run in JamLink mode
         { "srate", required_argument, NULL, 'T' }, // Set Sample Rate
+        { "deviceid", required_argument, NULL, 'd' }, // Set RTAudio device id to use
         { "bufsize", required_argument, NULL, 'F' }, // Set buffer Size
         { "nojackportsconnect" , no_argument, NULL,  'D'}, // Don't connect default Audio Ports
         { "version", no_argument, NULL, 'v' }, // Version Number
@@ -131,7 +133,7 @@ void Settings::parseInput(int argc, char** argv)
     /// \todo Specify mandatory arguments
     int ch;
     while ( (ch = getopt_long(argc, argv,
-                              "n:sc:SC:o:B:P:q:r:b:zljeJ:RT:F:Dvh", longopts, NULL)) != -1 )
+                              "n:sc:SC:o:B:P:q:r:b:zljeJ:RTd:F:Dvh", longopts, NULL)) != -1 )
         switch (ch) {
 
         case 'n': // Number of input and output channels
@@ -238,6 +240,11 @@ void Settings::parseInput(int argc, char** argv)
             mChanfeDefaultSR = true;
             mSampleRate = atoi(optarg);
             break;
+        case 'd': // RTAudio device id
+            //-------------------------------------------------------
+            mChanfeDefaultID = true;
+            mDeviceID = atoi(optarg);
+            break;
         case 'F': // Buffer Size
             //-------------------------------------------------------
             mChanfeDefaultBS = true;
@@ -321,6 +328,7 @@ void Settings::printUsage()
     cout << " --rtaudio                                Use system's default sound system instead of Jack" << endl;
     cout << "   --srate         #                      Set the sampling rate, works on --rtaudio mode only (default: 48000)" << endl;
     cout << "   --bufsize       #                      Set the buffer size, works on --rtaudio mode only (default: 128)" << endl;
+    cout << "   --deviceid      #                      The rtaudio device id --rtaudio mode only (default: 0)" << endl;
     cout << endl;
     cout << "HELP ARGUMENTS: " << endl;
     cout << " -v, --version                            Prints Version Number" << endl;
@@ -417,6 +425,11 @@ void Settings::startJackTrip()
         // Chanfe default Sampling Rate
         if (mChanfeDefaultSR) {
             mJackTrip->setSampleRate(mSampleRate);
+        }
+        
+        // Chanfe defualt device ID
+        if (mChanfeDefaultID) {
+            mJackTrip->setDeviceID(mDeviceID);
         }
 
         // Chanfe default Buffer Size

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -99,8 +99,10 @@ private:
   unsigned int mRedundancy; ///< Redundancy factor for data in the network
   bool mUseJack; ///< Use or not JackAduio
   bool mChanfeDefaultSR; ///< Change Default Sampling Rate
+  bool mChanfeDefaultID; ///< Change Default device ID
   bool mChanfeDefaultBS; ///< Change Default Buffer Size
   unsigned int mSampleRate;
+  unsigned int mDeviceID;
   unsigned int mAudioBufferSize;
   bool mConnectDefaultAudioPorts; ///< Connect or not jack audio ports
 };

--- a/src/jacktrip_globals.h
+++ b/src/jacktrip_globals.h
@@ -58,6 +58,7 @@ const AudioInterface::audioBitResolutionT gDefaultBitResolutionMode =
 const int gDefaultQueueLength = 4;
 const int gDefaultOutputQueueLength = 4;
 const uint32_t gDefaultSampleRate = 48000;
+const uint32_t gDefaultDeviceID = 0;
 const uint32_t gDefaultBufferSizeInSamples = 128;
 const QString gDefaultLocalAddress = QString();
 const int gDefaultRedundancy = 1;


### PR DESCRIPTION
## Select device ID when using `rtaudio`
Allow the selection of `device_id` when using `rtaudio` instead of relying on the default.

Should be used in conjunction with an `rtaudio` version that supports outputting the device ID on `audioprobe`